### PR TITLE
Debugger detector was incorrectly checking injected class name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out/
 bin/
 .project
 .classpath
+/.vs

--- a/src/main/groovy/me/biocomp/hubitat_ci/validation/DebuggerDetector.groovy
+++ b/src/main/groovy/me/biocomp/hubitat_ci/validation/DebuggerDetector.groovy
@@ -15,6 +15,6 @@ class DebuggerDetector {
      */
     boolean isTraceFromDebugger(StackTraceElement[] trace)
     {
-        return trace.findIndexOf {it.className == 'DUMMY' } != -1
+        return trace.findIndexOf { it.className.startsWith('DUMMY') } != -1
     }
 }


### PR DESCRIPTION
Was checking for class name 'DUMMY' while it was 'DUMMY$closure1' or something like that.