### PR TITLE
Spock invocation checking DeviceExecutor.getState breaks DeviceExecutor.getState mock

### DIFF
--- a/src/test/groovy/me/biocomp/hubitat_ci/app/AppSandboxTest.groovy
+++ b/src/test/groovy/me/biocomp/hubitat_ci/app/AppSandboxTest.groovy
@@ -1,5 +1,6 @@
 package me.biocomp.hubitat_ci.app
 
+import me.biocomp.hubitat_ci.api.app_api.AppExecutor
 import me.biocomp.hubitat_ci.validation.Flags
 import spock.lang.Specification
 
@@ -33,5 +34,23 @@ def realCoolingSetpointHandler(evt) {}
         then:
             AssertionError e = thrown()
             e.message.contains("'Thermostat' does not contain attribute 'badAttributeName'. Valid attributes are: [")
+    }
+
+    def "Can mock getState"() {
+        when:
+            def state = [testField: 'testValue'] // Defining state map
+
+            AppExecutor executorApi = Mock{
+                _*getState() >> state
+            }
+
+            def script = new HubitatAppSandbox("""
+def readState(String field) {
+    return state[field]
+}
+""").run(api: executorApi, validationFlags: [Flags.DontRequireParseMethodInDevice, Flags.DontValidateMetadata])
+
+        then:
+            'testValue' == script.readState("testField")
     }
 }

--- a/src/test/groovy/me/biocomp/hubitat_ci/device/DeviceSandboxTest.groovy
+++ b/src/test/groovy/me/biocomp/hubitat_ci/device/DeviceSandboxTest.groovy
@@ -97,4 +97,22 @@ def useMqtt()
         then:
             1 * mqtt.publish("a", "b")
     }
+
+    def "Can mock getState"() {
+        when:
+            def state = [testField: 'testValue'] // Defining state map
+
+            DeviceExecutor executorApi = Mock{
+                _*getState() >> state
+            }
+
+            def script = new HubitatDeviceSandbox("""
+def readState(String field) {
+    return state[field]
+}
+""").run(api: executorApi, validationFlags: [Flags.DontRequireParseMethodInDevice, Flags.DontValidateMetadata])
+
+        then:
+            'testValue' == script.readState("testField")
+    }
 }


### PR DESCRIPTION
I recently encountered this issue when I was trying to use the invocation checking to ensure that no unexpected functions are called during a test. The "Testing mocking getState - broken" is a simple test case that reproduces the issue. I tried to track down where the issue is comping from, but I didn't get very far.

This merge request also has a test for DeviceExecutor.getState mocking. I found examples for how to do this, but there aren't any tests for this specific functionality.