### PR TITLE
Fixed dynamicPage() processing to add pages in order of definition

### DIFF
--- a/src/main/groovy/me/biocomp/hubitat_ci/app/AppValidator.groovy
+++ b/src/main/groovy/me/biocomp/hubitat_ci/app/AppValidator.groovy
@@ -64,8 +64,8 @@ class AppValidator extends ValidatorBase{
 
         if (!hasFlag(Flags.DontValidatePreferences)) {
             // Needs to have pages
-            if (!okEmptyIfRegisteredDynamicPages || preferences.dynamicRegistrations.size() == 0) {
-                assert (preferences.pages.size() != 0 || preferences.dynamicPages.size() != 0): "preferences() has to have pages (got ${preferences.pages.size()}), dynamic pages (got ${preferences.dynamicPages.size()})"
+            if (!okEmptyIfRegisteredDynamicPages || preferences.dynamicPages.size() == 0) {
+                assert (preferences.allPages.size() != 0): "preferences() has to have at least one page"
             }
 
             // Page names must be unique
@@ -149,14 +149,13 @@ class AppValidator extends ValidatorBase{
         if (!hasFlag(Flags.AllowUnreachablePages)) {
             def reachablePages = [] as HashSet<String>
 
-            List<Page> pagesCombined = preferences.pages + preferences.dynamicPages
+            final def pagesCombined = preferences.allPages
 
             if (!pagesCombined.isEmpty()) {
                 def allPages = [] as HashMap<String, Page>;
                 (pagesCombined).each {
                     allPages[it.readName()] = it
                 }
-
 
                 addReachablePages(pagesCombined[0], allPages, reachablePages);
 

--- a/src/main/groovy/me/biocomp/hubitat_ci/app/preferences/Preferences.groovy
+++ b/src/main/groovy/me/biocomp/hubitat_ci/app/preferences/Preferences.groovy
@@ -7,6 +7,26 @@ import groovy.transform.TypeChecked
 @TypeChecked
 class Preferences
 {
+    /**
+     * Pages for multiple-page apps.*/
+    private final List<Page> pages = []
+
+    /**
+     * Dynamic pages for multiple-page apps.*/
+    private final List<Page> dynamicPages = []
+
+    /**
+     * Pages + dynamic pages in order of declaration
+     */
+    private final List<Page> allPages = []
+
+    final Map options = [:]
+
+    /**
+     * Used when preferences().section() is used directly.
+     * Not compatible with multiple pages.*/
+    Page specialSinglePage = null
+
     @CompileStatic
     void assignOptions(Map options) {
         if (options != null) {
@@ -14,18 +34,32 @@ class Preferences
         }
     }
 
-    /**
-     * Pages for multiple-page apps.*/
-    final List<Page> pages = []
+    void addPage(Page p)
+    {
+        pages << p
+        allPages << p
+    }
 
-    /**
-     * Dynamic pages for multiple-page apps.*/
-    final List<Page> dynamicPages = []
+    void addDynamicPage(Page p)
+    {
+        dynamicPages << p
+        allPages << p
+    }
 
-    /**
-     * Methods to be called to generate dynamic pages.
-     * Called via registerDynamicPages()*/
-    final List<Closure> dynamicRegistrations = []
+    List<Page> getPages()
+    {
+        return pages
+    }
+
+    List<Page> getDynamicPages()
+    {
+        return dynamicPages
+    }
+
+    List<Page> getAllPages()
+    {
+        return allPages
+    }
 
     @CompileStatic
     List<Input> getAllInputs()
@@ -35,21 +69,9 @@ class Preferences
         }.flatten()
     }
 
-    final Map options = [:]
-
-    /**
-     * Used when preferences().section() is used directly.
-     * Not compatible with multiple pages.*/
-    Page specialSinglePage = null
-
     boolean hasSpecialSinglePage()
     {
         return this.@specialSinglePage != null
-    }
-
-    List<Page> getAllPages()
-    {
-        return pages + dynamicPages
     }
 
     Page getSpecialSinglePage() {
@@ -57,7 +79,7 @@ class Preferences
 
         if (!hasSpecialSinglePage()) {
             this.@specialSinglePage = Page.makeSinglePage()
-            pages << this.@specialSinglePage
+            addPage(this.@specialSinglePage)
         }
 
         return this.@specialSinglePage


### PR DESCRIPTION
Dynamic page handlers were called after all static pages were added.
This caused an issue with detecting reachable pages.
Reachable pages start discovery of pages from the first page, which was incorrect if first page was dynamic (and therefore was added after static pages).