### PR TITLE
Fix setters and getters to handle methods, and metaclass overrides.

### DIFF
--- a/src/main/groovy/me/biocomp/hubitat_ci/app/MappingPath.groovy
+++ b/src/main/groovy/me/biocomp/hubitat_ci/app/MappingPath.groovy
@@ -24,7 +24,7 @@ class MappingPath {
     {
         return { HubitatAppScript script, def params, def request ->
             def scriptWithInjectedProps = script.getMetaClass().invokeConstructor()
-            scriptWithInjectedProps.metaClass = script.metaClass
+            scriptWithInjectedProps.setMetaClass(script.getMetaClass())
 
             scriptWithInjectedProps.initialize(script)
             scriptWithInjectedProps.installMappingInjectedProps(params, request)

--- a/src/main/groovy/me/biocomp/hubitat_ci/util/ScriptUtil.groovy
+++ b/src/main/groovy/me/biocomp/hubitat_ci/util/ScriptUtil.groovy
@@ -1,0 +1,81 @@
+package me.biocomp.hubitat_ci.util
+
+import groovy.transform.CompileStatic
+
+import java.lang.reflect.Method
+
+@CompileStatic
+class ScriptUtil {
+
+    static def handleGetProperty(String property, def scriptObject, Map userSettingsMap)
+    {
+        switch (property) {
+            case "metaClass":
+                return scriptObject.getMetaClass()
+
+        // default: - continue processing below
+        }
+
+        final def getterMethodName = "get${property.capitalize()}"
+        try {
+            // Simple implementation of redirecting getter back to script class (if present)
+            final def getter = scriptObject.getClass().getMethod(getterMethodName, [] as Class[])
+            return getter.invoke(scriptObject);
+        } catch (NoSuchMethodException e) {
+            // It's OK, it might be handled below
+        }
+
+        final def scriptMetaClass = scriptObject.getMetaClass()
+
+        // There's a property, return it.
+        // This is to support overriding inputs via meta classes
+        if (scriptMetaClass.hasProperty(scriptObject, property)) {
+            return scriptMetaClass.getProperty(scriptObject as GroovyObjectSupport, property)
+        }
+        // It's a method. Hubitat returns string in this case.
+        else if (scriptMetaClass.methods.find{ it.name == property } != null) {
+            return property
+        }
+
+        // Use settings map
+        return userSettingsMap.get(property)
+    }
+
+    // Just pick first method with same name and one parameter.
+    // We can't distinguish parameters because we may not know newValue class if it's null.
+    private static Method findSetterMethod(String methodName, def scriptObject)
+    {
+        final def foundMethods = scriptObject.getClass().methods.findAll{ it.name == methodName && it.parameters.size() == 1 }
+        if (!foundMethods.empty)
+        {
+            return foundMethods.first()
+        }
+
+        null
+    }
+
+    static void handleSetProperty(String property, def scriptObject, def newValue, Map userSettingsMap)
+    {
+        // Handle special cases
+        switch (property)
+        {
+            case "metaClass":
+                scriptObject.setMetaClass((MetaClass) newValue);
+                return;
+
+        // default: - continue processing below
+        }
+
+        // Simple implementation of redirecting getter back to the script class (if present)
+        final def setterMethodName = "set${property.capitalize()}"
+        final def setter = findSetterMethod(setterMethodName, scriptObject)
+        if (setter != null)
+        {
+            setter.invoke(scriptObject, newValue)
+            return
+        }
+
+        // Use settings
+        userSettingsMap.put(property, newValue)
+    }
+}


### PR DESCRIPTION
Seems like hubitat, when passing method into another method (like calling `unschedule(myHandler)`) does something that groovy doesn't. It will just replace method name with the string, so `unschedule` in that case would be called as `unschedule("myHandler")`.

Fixing my implementation to do the same, while also adding more tests and using common getter/setter code for both App and Device script classes.