### PR TITLE
Implements the toDateTime(String) interface of AppExecutor.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ publishing {
 
 dependencies {
     implementation 'org.codehaus.groovy:groovy-all:2.5.4'
+    implementation 'org.codehaus.groovy:groovy-dateutil:2.5.4'
     implementation 'org.ow2.asm:asm:7.0'
 
     implementation 'su.litvak.chromecast:api-v2:0.11.1'

--- a/src/main/groovy/me/biocomp/hubitat_ci/util/AppExecutorWithEventForwarding.groovy
+++ b/src/main/groovy/me/biocomp/hubitat_ci/util/AppExecutorWithEventForwarding.groovy
@@ -15,6 +15,13 @@ abstract class AppExecutorWithEventForwarding implements AppExecutor {
 
     private HubitatAppScript script
 
+    @Override
+    Date toDateTime(String dateTimeString) {
+        // Hubitat hub converts dates to strings when you store them in state.  It uses the
+        // format: 2020-11-02T14:32:17+0000
+        return Date.parse("yyyy-MM-dd'T'HH:mm:ssZ", dateTimeString)
+    }
+
     void setSubscribingScript(HubitatAppScript script) {
         this.script = script
     }

--- a/src/test/groovy/me/biocomp/hubitat_ci/util/AppExecutorWithEventForwardingTest.groovy
+++ b/src/test/groovy/me/biocomp/hubitat_ci/util/AppExecutorWithEventForwardingTest.groovy
@@ -101,4 +101,17 @@ class AppExecutorWithEventForwardingTest extends Specification {
         then:
         0 * appScript.levelHandler(_)
     }
+
+    def "Dates are parsed correctly by toDateTime method" () {
+        given:
+        def dateString = "2020-11-02T14:32:17+0000"
+
+        when:
+        def date = appExecutor.toDateTime(dateString)
+
+        then:
+        // This is the format that Hubitat hub uses when it converts dates to strings
+        // (as it does when storing a date in app or device state)
+        date.format("yyyy-MM-dd'T'HH:mm:ssZ", TimeZone.getTimeZone('UTC')) == dateString
+    }
 }


### PR DESCRIPTION
  App and device scripts can store values in state.  However, the Hubitat hub has to serialize these values so it can store them in its db.  A really common case for many app scripts is to store dates in state, and Hubitat then serializes the date.

  To aid in deserialization, Hubitat has a method called toDateTime(String), and this is part of the AppExecutor interface.

  This PR provides a hub-compatible implementation of toDateTime(String).